### PR TITLE
Tweaks to home page

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -7,8 +7,8 @@ description = "A container sandbox runtime focused on security, efficiency, and 
 {{< blocks/cover image_anchor="top" height="auto" color="primary" title="gVisor" >}}
 <div class="mx-auto" style="margin-bottom: 8rem !important;">
   <p class="lead" style="font-size: 1.6rem">A container sandbox runtime focused on <strong>security</strong>, <strong>efficiency</strong>, and <strong>ease of use</strong>.</p>
-  <a class="btn btn-lg btn-secondary mr-3 mb-4" href="./docs/user_guide/docker/" >Quick Start<i class="fas fa-arrow-alt-circle-right ml-2"></i></a>
-  <a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/google/gvisor" rel="noopener">GitHub <i class="fab fa-github ml-2 "></i></a>
+  <a class="btn btn-lg btn-secondary mr-3 mb-4" href="./docs/user_guide/docker/">Quick Start<i class="fas fa-arrow-alt-circle-right ml-2"></i></a>
+  <a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/google/gvisor" rel="noopener">GitHub <i class="fab fa-github ml-2"></i></a>
 </div>
 {{< /blocks/cover >}}
 
@@ -29,14 +29,14 @@ Runs as a normal process and uses the host kernel for memory management and sche
 {{% /blocks/feature %}}
 
 {{% blocks/feature icon="fab fa-linux" title="Zero Configuration" %}}
-Capable of running most Linux applications unmodified with zero configuration.
+Capable of running most Linux applications unmodified, with zero configuration.
 {{% /blocks/feature %}}
 
 {{< /blocks/section >}}
 
 {{< blocks/section color="white" >}}
 
-{{% blocks/feature icon="fas fa-book" title="Read the docs" %}}
+{{% blocks/feature icon="fas fa-book" title="Read the Docs" %}}
 Read the [documentation](./docs/user_guide/) to understand gVisor, its architecture and trade-offs, and how to use it.
 {{% /blocks/feature %}}
 


### PR DESCRIPTION
* Fix "Read the docs" to use consistent case with the rest of the callouts at the bottom of the page.
* Add a comma to the Zero Configuration callout to make it read better.
* Remove a few extra spaces from the HTML.