### PR TITLE
Reword to remove duplicate "Linux"

### DIFF
--- a/content/docs/includes/install_gvisor.md
+++ b/content/docs/includes/install_gvisor.md
@@ -1,4 +1,4 @@
-> Note: gVisor requires Linux x86\_64 Linux 3.17+.
+> Note: gVisor supports only x86\_64 and requires Linux 3.17+.
 
 The easiest way to get `runsc` is from the [latest nightly
 build][latest-nightly]. After you download the binary, check it against the


### PR DESCRIPTION
"Linux x86_64 Linux 3.17+" is wordy. Reword to mention Linux only once.