### PR TITLE
Remove unnecessary curly braces around bash commands.

### DIFF
--- a/content/docs/includes/install_gvisor.md
+++ b/content/docs/includes/install_gvisor.md
@@ -16,13 +16,11 @@ user `nobody` to avoid unnecessary privileges. The `/usr/local/bin` directory is
 a good place to put the `runsc` binary.
 
 ```bash
-{
-  wget https://storage.googleapis.com/gvisor/releases/nightly/latest/runsc
-  wget https://storage.googleapis.com/gvisor/releases/nightly/latest/runsc.sha512
-  sha512sum -c runsc.sha512
-  chmod a+x runsc
-  sudo mv runsc /usr/local/bin
-}
+wget https://storage.googleapis.com/gvisor/releases/nightly/latest/runsc
+wget https://storage.googleapis.com/gvisor/releases/nightly/latest/runsc.sha512
+sha512sum -c runsc.sha512
+chmod a+x runsc
+sudo mv runsc /usr/local/bin
 ```
 
 [latest-nightly]: https://storage.googleapis.com/gvisor/releases/nightly/latest/runsc

--- a/content/docs/user_guide/oci.md
+++ b/content/docs/user_guide/oci.md
@@ -15,20 +15,16 @@ Now we will create an [OCI][oci] container bundle to run our container. First we
 will create a root directory for our bundle.
 
 ```bash
-{
-  mkdir bundle
-  cd bundle
-}
+mkdir bundle
+cd bundle
 ```
 
 Create a root file system for the container. We will use the Docker hello-world
 image as the basis for our container.
 
 ```bash
-{
-  mkdir rootfs
-  docker export $(docker create hello-world) | tar -xf - -C rootfs
-}
+mkdir rootfs
+docker export $(docker create hello-world) | tar -xf - -C rootfs
 ```
 
 Next, create an specification file called `config.json` that contains our
@@ -36,10 +32,8 @@ container specification. We will update the default command it runs to `/hello`
 in the `hello-world` container.
 
 ```bash
-{
-  runsc spec
-  sed -i 's;"sh";"/hello";' config.json
-}
+runsc spec
+sed -i 's;"sh";"/hello";' config.json
 ```
 
 Finally run the container.


### PR DESCRIPTION
Some of bash is surrounded by curly braces, probably left over from copying JSON blocks.