### PR TITLE
Fix feature block rendering (fixes #56)

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -20,32 +20,32 @@ gVisor integrates with <a href="https://www.docker.com/" target="_blank" rel="no
 
 {{< blocks/section color="dark" >}}
 
-{{< blocks/feature icon="fas fa-lock" title="Defense in Depth" >}}
+{{% blocks/feature icon="fas fa-lock" title="Defense in Depth" %}}
 Each sandbox has its own user-space kernel, providing additional protection from host kernel vulnerabilities.
-{{< /blocks/feature >}}
+{{% /blocks/feature %}}
 
-{{< blocks/feature icon="fas fa-feather-alt" title="Lightweight" >}}
+{{% blocks/feature icon="fas fa-feather-alt" title="Lightweight" %}}
 Runs as a normal process and uses the host kernel for memory management and scheduling.
-{{< /blocks/feature >}}
+{{% /blocks/feature %}}
 
-{{< blocks/feature icon="fab fa-linux" title="Zero Configuration" >}}
+{{% blocks/feature icon="fab fa-linux" title="Zero Configuration" %}}
 Capable of running most Linux applications unmodified, with zero configuration.
-{{< /blocks/feature >}}
+{{% /blocks/feature %}}
 
 {{< /blocks/section >}}
 
 {{< blocks/section color="white" >}}
 
-{{< blocks/feature icon="fas fa-book" title="Read the Docs" >}}
+{{% blocks/feature icon="fas fa-book" title="Read the Docs" %}}
 Read the [documentation](./docs/) to understand gVisor, its architecture and trade-offs, and how to use it.
-{{< /blocks/feature >}}
+{{% /blocks/feature %}}
 
-{{< blocks/feature icon="fas fa-code-branch" title="Contribute to gVisor" >}}
+{{% blocks/feature icon="fas fa-code-branch" title="Contribute to gVisor" %}}
 Anyone is welcome to be a gVisor contributor. Please check out the [community information](./docs/community) to get started.
-{{< /blocks/feature >}}
+{{% /blocks/feature %}}
 
-{{< blocks/feature icon="fab fa-github" title="Give Feedback" >}}
+{{% blocks/feature icon="fab fa-github" title="Give Feedback" %}}
 File feature requests, bugs, and compatibility issues on <a href="https://github.com/google/gvisor/issues" target="_blank" rel="noopener">GitHub</a>.
-{{< /blocks/feature >}}
+{{% /blocks/feature %}}
 
 {{< /blocks/section >}}

--- a/layouts/shortcodes/blocks/feature.html
+++ b/layouts/shortcodes/blocks/feature.html
@@ -1,0 +1,10 @@
+{{ $icon := .Get "icon" | default "fa-lightbulb" }}
+{{ $url_text := .Get "url_text" }}
+<div class="col-lg-4 mb-5 mb-lg-0 text-center ">
+  <div class="mb-4 h1">
+    <i class="{{ if not (or (hasPrefix $icon "fas ") (hasPrefix $icon "fab ")) }}fas {{ end }}{{ $icon }}"></i>
+  </div>
+  <h4 class="h3">{{ .Get "title" | markdownify }}</h4>
+  <div class="mb-0">{{ .Inner }}</div>
+  {{ with .Get "url" }}<p><a href="{{ . }}">{{ with $url_text }}{{ $url_text }}{{ else }}{{ T "ui_read_more" }}{{ end }} …</a></p>{{ end }}
+</div>


### PR DESCRIPTION
- Render feature blocks as markdown again.
- Feature block inner content is contained in a `<div>` rather than a `<p>`
  to avoid nested `<p>` tags.