### PR TITLE
Changed example command for profiling CPU/heap

### DIFF
--- a/content/docs/user_guide/debugging.md
+++ b/content/docs/user_guide/debugging.md
@@ -89,7 +89,7 @@ the options available:
 For example:
 
 ```bash
-docker run --runtime=runsc-prof --rm -d alpine sleep 1000
+docker run --runtime=runsc-prof --rm -d alpine sh -c "while true; do echo running; sleep .1; done"
 63254c6ab3a6989623fa1fb53616951eed31ac605a2637bb9ddba5d8d404b35b
 
 sudo runsc --root /var/run/docker/runtime-runsc-prof/moby debug --profile-heap=/tmp/heap.prof 63254c6ab3a6989623fa1fb53616951eed31ac605a2637bb9ddba5d8d404b35b

--- a/content/docs/user_guide/debugging.md
+++ b/content/docs/user_guide/debugging.md
@@ -46,7 +46,7 @@ gVisor. It connects to the sandbox process, collects a stack dump, and writes
 it to the console. For example:
 
 ```bash
-docker run --runtime=runsc --rm -d alpine sh -c "while true; do echo running; sleep .1; done"
+docker run --runtime=runsc --rm -d alpine sh -c "while true; do echo running; sleep 1; done"
 63254c6ab3a6989623fa1fb53616951eed31ac605a2637bb9ddba5d8d404b35b
 
 sudo runsc --root /var/run/docker/runtime-runsc/moby debug --stacks 63254c6ab3a6989623fa1fb53616951eed31ac605a2637bb9ddba5d8d404b35b
@@ -89,7 +89,7 @@ the options available:
 For example:
 
 ```bash
-docker run --runtime=runsc-prof --rm -d alpine sh -c "while true; do echo running; sleep .1; done"
+docker run --runtime=runsc-prof --rm -d alpine sh -c "while true; do echo running; sleep 1; done"
 63254c6ab3a6989623fa1fb53616951eed31ac605a2637bb9ddba5d8d404b35b
 
 sudo runsc --root /var/run/docker/runtime-runsc-prof/moby debug --profile-heap=/tmp/heap.prof 63254c6ab3a6989623fa1fb53616951eed31ac605a2637bb9ddba5d8d404b35b


### PR DESCRIPTION
Profiling a container that runs `sleep 1000` command dumps an empty CPU profile that may cause unnecessary questions. I suggest replacing this example with one mentioned in the same doc above.