### PR TITLE
Add fragment links to sub-headers in docs (fixes #61)

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -72,3 +72,10 @@ a.doc-table-anchor {
 .td-default main section.td-cover-block p.lead strong {
     font-weight: bold;
 }
+
+.td-page,.td-section {
+    main a.header-link {
+        color: inherit;
+        font-size: 60%;
+    }
+}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -10,3 +10,10 @@
 <script src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}"></script>
 {{ end }}
 {{ partial "hooks/body-end.html" . }}
+
+<script type="text/javascript">
+  $("body.td-page,body.td-section").find("main h2,h3,h4").each(function() {
+    var fragment = $(this).attr('id');
+    $(this).append('&nbsp;<a href="#'+fragment+'" class="header-link"><i class="fas fa-link"></i></a>');
+  });
+</script>


### PR DESCRIPTION
Allows users to copy links to sub-headers within docs.