### PR TITLE
Add redirect from old URL.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,12 @@ compatibility-docs: bin/generate-syscall-docs upstream/gvisor/bazel-bin/runsc/li
 .PHONY: compatibility-docs
 
 # Run a local content development server. Redirects will not be supported.
-server: all-upstream compatibility-docs
+devserver: all-upstream compatibility-docs
 	$(HUGO) server -FD --port 8080
+.PHONY: server
+
+server: website
+	cd public/ && go run main.go --custom-domain localhost
 .PHONY: server
 
 # Deploy the website to App Engine.

--- a/cmd/gvisor-website/main.go
+++ b/cmd/gvisor-website/main.go
@@ -36,8 +36,11 @@ var redirects = map[string]string{
 	"/pr":        "https://github.com/google/gvisor/pulls",
 
 	// Redirects to compatibility docs.
-	"/c":             "/docs/user_guide/compatibility",
-	"/c/linux/amd64": "/docs/user_guide/compatibility/linux/amd64",
+	"/c":             "/docs/user_guide/compatibility/",
+	"/c/linux/amd64": "/docs/user_guide/compatibility/linux/amd64/",
+	// Redirect for old url
+	"/docs/user_guide/compatibility/amd64":  "/docs/user_guide/compatibility/linux/amd64/",
+	"/docs/user_guide/compatibility/amd64/": "/docs/user_guide/compatibility/linux/amd64/",
 
 	// Deprecated, but links continue to work.
 	"/cl": "https://gvisor-review.googlesource.com",
@@ -230,5 +233,6 @@ func main() {
 	registerRebuild(nil)
 	registerStatic(nil, *staticDir)
 
+	log.Printf("Listening on %s...", *addr)
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }


### PR DESCRIPTION
- Adds url redirect from old syscall docs url to new url
- make server now runs the Go server and implements redirects.
- make devserver runs the hugo dev server.