### PR TITLE
Fix install link in Docker quickstart

### DIFF
--- a/content/docs/user_guide/quick_start/docker.md
+++ b/content/docs/user_guide/quick_start/docker.md
@@ -90,7 +90,7 @@ Next, look at the different options available for gVisor: [platform][platforms],
 
 [docker]: https://docs.docker.com/install/
 [storage-driver]: https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-storage-driver
-
+[install]: /docs/user_guide/install/
 [filesystem]: /docs/user_guide/filesystem/
 [networking]: /docs/user_guide/networking/
 [platforms]: /docs/user_guide/platforms/


### PR DESCRIPTION
Link to install docs is currently missing from the Docker quickstart page. This change introduces the markdown link.