### PR TITLE
Remove pointers to releases that do not exist yet.

### DIFF
--- a/content/docs/user_guide/install.md
+++ b/content/docs/user_guide/install.md
@@ -25,11 +25,15 @@ to the preferred installation mechanism: manual or from an `apt` repository.
 Nightly releases are built most nights from the master branch, and are available
 at the following URL:
 
-   `https://storage.googleapis.com/gvisor/releases/nightly/latest`
+   `https://storage.googleapis.com/gvisor/releases/nightly/latest/runsc`
+
+Checksums for the release binary are at:
+
+   `https://storage.googleapis.com/gvisor/releases/nightly/latest/runsc.sha512`
 
 Specific nightly releases can be found at:
 
-   `https://storage.googleapis.com/gvisor/releases/nightly/${yyyy-mm-dd}`
+   `https://storage.googleapis.com/gvisor/releases/nightly/${yyyy-mm-dd}/runsc`
 
 Note that a release may not be available for every day.
 
@@ -38,20 +42,14 @@ Note that a release may not be available for every day.
 To use a nightly release, use one of the above URLs for `URL` in the manual
 instructions below. For `apt`, use `nightly` for `DIST` below.
 
- -->
-
 ### Latest release
 
 The latest official release is available at the following URL:
 
    `https://storage.googleapis.com/gvisor/releases/release/latest`
 
-<!--
-
 To use the latest release, use the above URL for `URL` in the manual
 instructions below. For `apt`, use `latest` for `DIST` below.
-
- -->
 
 ### Specific release
 
@@ -61,13 +59,11 @@ A given release release is available at the following URL:
 
 See the [releases][releases] page for information about specific releases.
 
-<!--
 
 This will include point updates for the release, if required. To use a specific
 release, use the above URL for `URL` in the manual instructions below. For
 `apt`, use `${yyyymmdd}` for `DIST` below.
 
- -->
 
 ### Point release
 
@@ -75,7 +71,6 @@ A given point release is available at the following URL:
 
   `https://storage.googleapis.com/gvisor/releases/release/${yyyymmdd}.${rc}`
 
-<!--
 
 Unlike the specific release above, which may include updates, this release will
 not change. To use a specific point release, use the above URL for `URL` in the
@@ -140,18 +135,13 @@ If you have Docker installed, it will be automatically configured.
 
 -->
 
-## Install manually
-
-After selecting an appropriate `URL` above, you can download `runsc` directly
-from `${URL}/runsc` ([latest][latest-nightly]) and a checksum hash from
-`${URL}/runsc.sha512` ([latest][latest-hash]).
-
-For example, this binary can be downloaded, validated, and placed in an
-appropriate location by running:
+For example, the latest nightly binary can be downloaded, validated, 
+and placed in an appropriate location by running:
 
 ```bash
 (
   set -e
+  URL=https://storage.googleapis.com/gvisor/releases/nightly/latest
   wget ${URL}/runsc
   wget ${URL}/runsc.sha512
   sha512sum -c runsc.sha512


### PR DESCRIPTION
And simplify installation instructions.

Multiple users reported that the download links (even for our nightlys) are broken.  While the instructions for the nightlys were technically correct, they were hard to follow, and kind of misleading.