### PR TITLE
Fix broken "Edit this page" link

### DIFF
--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -5,9 +5,9 @@
 {{ if $gh_repo }}
 <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
 {{ $editURL := printf "%s/edit/master/content/%s" $gh_repo .Path }}
-{{ if and ($gh_subdir) (.Site.Language.Lang) }}
+{{ if and ($gh_subdir) (.Site.IsMultiLingual) }}
 {{ $editURL = printf "%s/edit/master/%s/content/%s/%s" $gh_repo $gh_subdir ($.Site.Language.Lang) $.Path }}
-{{ else if .Site.Language.Lang }}
+{{ else if .Site.IsMultiLingual }}
 {{ $editURL = printf "%s/edit/master/content/%s/%s" $gh_repo ($.Site.Language.Lang) .Path }}
 {{ else if $gh_subdir }}
 {{ $editURL = printf "%s/edit/master/%s/content/%s" $gh_repo $gh_subdir $.Path }}

--- a/themes/docsy/layouts/partials/page-meta-links.html
+++ b/themes/docsy/layouts/partials/page-meta-links.html
@@ -5,9 +5,9 @@
 {{ if $gh_repo }}
 <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
 {{ $editURL := printf "%s/edit/master/content/%s" $gh_repo .Path }}
-{{ if and ($gh_subdir) (.Site.Language.Lang) }}
+{{ if and ($gh_subdir) (.Site.IsMultiLingual) }}
 {{ $editURL = printf "%s/edit/master/%s/content/%s/%s" $gh_repo $gh_subdir ($.Site.Language.Lang) $.Path }}
-{{ else if .Site.Language.Lang }}
+{{ else if .Site.IsMultiLingual }}
 {{ $editURL = printf "%s/edit/master/content/%s/%s" $gh_repo ($.Site.Language.Lang) .Path }}
 {{ else if $gh_subdir }}
 {{ $editURL = printf "%s/edit/master/%s/content/%s" $gh_repo $gh_subdir $.Path }}


### PR DESCRIPTION
It's broken again!

According [this issue in docsy](https://github.com/google/docsy/issues/138), it appears that they don't have an elegant solution yet, and they also suggest us to override the file temporarily. So I guess we can just use [a workable version from docsy](https://github.com/google/docsy/commit/b04bf7930).