### PR TITLE
Use Docker images for build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 HUGO := hugo
 HUGO_VERSION := 0.53
 HTMLPROOFER_VERSION := 3.10.2
-NPM := npm
 GCLOUD := gcloud
 GCP_PROJECT := gvisor-website
 
@@ -55,7 +54,14 @@ static-staging: compatibility-docs node_modules config.toml $(shell find archety
 node_modules: package.json package-lock.json
 	# Use npm ci because npm install will update the package-lock.json.
 	# See: https://github.com/npm/npm/issues/18286
-	$(NPM) ci
+	docker run \
+	  -e USER="$(shell id -u)" \
+	  -e HOME="/tmp" \
+	  -u="$(shell id -u):$(shell id -g)" \
+	  -v $(PWD):/workspace \
+	  -w /workspace \
+	  --entrypoint 'npm' \
+	  node ci
 
 upstream/gvisor/bazel-bin/runsc/linux_amd64_pure_stripped/runsc: upstream-gvisor
 	mkdir -p /tmp/gvisor-website/build_output

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,17 @@ node_modules: package.json package-lock.json
 	$(NPM) ci
 
 upstream/gvisor/bazel-bin/runsc/linux_amd64_pure_stripped/runsc: upstream-gvisor
-	cd upstream/gvisor && bazel build runsc
+	mkdir -p /tmp/gvisor-website/build_output
+	docker run \
+	  -v $(PWD)/upstream/gvisor:/workspace \
+	  -v /tmp/gvisor-website/build_output:/tmp/gvisor-website/build_output \
+	  -w /workspace \
+	  --entrypoint 'sh' \
+	  l.gcr.io/google/bazel \
+	  -c '\
+		groupadd --gid $(shell id -g) $(shell id -gn) && \
+		useradd --uid $(shell id -u) --gid $(shell id -g) -ms /bin/bash $(USER) && \
+		su $(USER) -c "bazel --output_user_root=/tmp/gvisor-website/build_output build //runsc"'
 
 bin/generate-syscall-docs: $(GEN_SOURCE)
 	mkdir -p bin/

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ $(APP_TARGET): public $(APP_SOURCE)
 
 static-production: hugo-docker-image compatibility-docs node_modules config.toml $(shell find archetypes assets content themes -type f | sed 's/ /\\ /g')
 	docker run \
+	  --rm \
 	  -e HUGO_ENV="production" \
 	  -e USER="$(shell id -u)" \
 	  -e HOME="/tmp" \
@@ -56,6 +57,7 @@ static-production: hugo-docker-image compatibility-docs node_modules config.toml
 
 static-staging: hugo-docker-image compatibility-docs node_modules config.toml $(shell find archetypes assets content themes -type f | sed 's/ /\\ /g')                           
 	docker run \
+	  --rm \
 	  -e HUGO_ENV="production" \
 	  -e USER="$(shell id -u)" \
 	  -e HOME="/tmp" \
@@ -71,6 +73,7 @@ node_modules: package.json package-lock.json
 	# Use npm ci because npm install will update the package-lock.json.
 	# See: https://github.com/npm/npm/issues/18286
 	docker run \
+	  --rm \
 	  -e USER="$(shell id -u)" \
 	  -e HOME="/tmp" \
 	  -u="$(shell id -u):$(shell id -g)" \
@@ -82,6 +85,7 @@ node_modules: package.json package-lock.json
 upstream/gvisor/bazel-bin/runsc/linux_amd64_pure_stripped/runsc: upstream-gvisor
 	mkdir -p /tmp/gvisor-website/build_output
 	docker run \
+	  --rm \
 	  -v $(PWD)/upstream/gvisor:/workspace \
 	  -v /tmp/gvisor-website/build_output:/tmp/gvisor-website/build_output \
 	  -w /workspace \
@@ -107,6 +111,7 @@ check: htmlproofer-docker-image website
 # Run a local content development server. Redirects will not be supported.
 devserver: hugo-docker-image all-upstream compatibility-docs
 	docker run \
+	  --rm \
 	  -e USER="$(shell id -u)" \
 	  -e HOME="/tmp" \
 	  -u="$(shell id -u):$(shell id -g)" \
@@ -123,11 +128,6 @@ devserver: hugo-docker-image all-upstream compatibility-docs
 server: website
 	cd public/ && go run main.go --custom-domain localhost
 .PHONY: server
-
-# Deploy the website to App Engine.
-deploy: website
-	cd public && $(GCLOUD) app deploy
-.PHONY: deploy
 
 # Stage the website to App Engine at a version based on the git branch name.
 stage: all-upstream app static-staging

--- a/README.md
+++ b/README.md
@@ -4,24 +4,14 @@ This repository holds the content for the gVisor website. It uses
 [hugo](https://gohugo.io/) to generate the website and
 [Docsy](https://github.com/google/docsy) as the theme. 
 
-## Requirements
+## Using Github
 
-Building the website requires the extended version of
-[hugo](https://gohugo.io/) and [node.js](https://nodejs.org/) in order to
-generate CSS files. Please install them before building.
+The easiest way to contribute to the documentation is to use the "Edit this
+page" link on any documentation page to edit the page content directly via
+GitHub and submit a pull request. This should generally be done for changes to 
+a single page.
 
-- Node.js >= 10.15.0 LTS
-- hugo extended >= v0.53
-
-## Contributing to Documentation
-
-### Using Github
-
-You can use the "Edit this page" link on any documentation page to edit the
-page content directly via GitHub and submit a pull request. This should
-generally be done for relatively small changes.
-
-### Using Git
+## Using Git
 
 You can submit pull requests by making changes in a Git branch. See more
 information on GitHub pull requests
@@ -32,47 +22,37 @@ Documentation is written in markdown with hugo extensions. Please read more
 about [content management](https://gohugo.io/categories/content-management) in
 the hugo documentation.
 
-You can use the hugo web server for testing. This will start a webserver that
-will rebuild the site when you make content changes:
+### Requirements
 
-```
-make server
-```
+Building the website requires [Docker](https://www.docker.com/). Please
+[install](https://docs.docker.com/install/) it before building.
 
-Access the site at http://localhost:8080
+### Building
 
-## Building
-
-If you are making changes to App Engine config or application code, you can
-build the website using `make`. This will output the App Engine application
-code, configuration, and html and CSS into the `public/` directory.
+If you want to simply build the website, you can do that using `make`. This
+will output the App Engine application code, configuration, and html and CSS
+into the `public/` directory.
 
 ```
 make
 ```
 
-If you have Go installed you can run a local version of the website via the
-`public/` directory.
+### Testing
+
+You can use the hugo web server for testing documentation or style changes.
+This will start a webserver that will rebuild the site when you make content
+changes:
 
 ```
-cd public/
-go run main.go
+make devserver
 ```
 
 Access the site at http://localhost:8080
 
-## Troubleshooting
-
-#### I get errors when building the website.
-
-If you get the following errors you should check that you have the "extended"
-version of Hugo. This is the version of hugo named "hugo\_extended" on the
-[releases page](https://github.com/gohugoio/hugo/releases).
+If you need to test all functionality including redirects you can start the App
+Engine app locally. However, you will need to restart the app when making
+content changes:
 
 ```
-ERROR 2019/04/03 11:25:58 Failed to add template "partials/navbar.html" in path "/home/me/gvisor-website/layouts/partials/navbar.html": template: partials/navbar.html:5: function "resources" not defined
-ERROR 2019/04/03 11:25:58 partials/navbar.html : template: partials/navbar.html:5: function "resources" not defined
-ERROR 2019/04/03 11:25:58 Unable to locate template for shortcode "readfile" in page "docs/user_guide/docker.md"
-ERROR 2019/04/03 11:25:58 Unable to locate template for shortcode "readfile" in page "docs/user_guide/oci.md"
-ERROR 2019/04/03 11:25:58 Unable to locate template for shortcode "blocks" in page "_index.html"
+make server
 ```

--- a/cloudbuild/html-proofer/Dockerfile
+++ b/cloudbuild/html-proofer/Dockerfile
@@ -13,7 +13,7 @@ RUN set -x \
             libcurl \
             libxml2-dev \
             libxslt-dev \
-            openssh
+            openssh \
         && gem install \
             html-proofer:${HTMLPROOFER_VERSION} \
             nokogiri:1.10.1 \


### PR DESCRIPTION
Removes the local build dependencies on Bazel, node.js/npm, and hugo and uses Docker to build runsc and the website. This should make it easier for folks to build it as it just requires Docker, make, and git to run.

Fixes #128 
