### PR TITLE
Fix corrupted bazel install errors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin/
+bazel_user_root/
 public/
 resources/
 node_modules/


### PR DESCRIPTION
Previously /tmp/gvisor-website was used for the bazel output_user_root
but the host could delete a subset of the files under /tmp causing it to
become corrupted.

This commit updates the Makefile to use the bazel_user_root directory
under the repository root directory for caching bazel packages.